### PR TITLE
Fixed: QuantumultX invalid cert error

### DIFF
--- a/QuantumultX/QuantumultX.conf
+++ b/QuantumultX/QuantumultX.conf
@@ -97,7 +97,7 @@ final, Others
 (?<=(carrier|account|sys)_region=)CN url 307 KR
 
 [mitm]
-# 请在正式使用前将其他已信任证书的密码及 P12 填入下方，或前往设置界面生成、安装并信任证书
-passphrase =
-p12 =
+# 请在正式使用前将其他已信任证书的密码及 P12 填入下方，并删掉 passphrase 和 p12 前的分号。或者前往设置界面生成、安装并信任证书
+;passphrase =
+;p12 =
 hostname = api*.tiktokv.com, api*.musical.ly, api*.amemv.com, aweme*.snssdk.com


### PR DESCRIPTION
注释 passphrase 和 p12，以解决 QuantumultX 生成证书时提示证书无效的错误。