### PR TITLE
Fix Loon doh3-server configuration

### DIFF
--- a/Loon/Loon.conf
+++ b/Loon/Loon.conf
@@ -11,7 +11,7 @@ bypass-tun = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,1
 ## 若你的 Loon 版本低于 2.2.0(427) 请使用 # 暂时注释下方 doh-server 和 doh3-server
 dns-server = 1.0.0.1,8.8.8.8,119.29.29.29,223.5.5.5
 doh-server = https://dns.alidns.com/dns-query
-doh3-server = https://223.5.5.5/dns-query,https://223.6.6.6/dns-query
+doh3-server = h3://223.5.5.5/dns-query,h3://223.6.6.6/dns-query
 # Wi-Fi 访问
 allow-udp-proxy = false
 allow-wifi-access = false


### PR DESCRIPTION
doh3-server 配置应为 h3://223.5.5.5/dns-query,h3://223.6.6.6/dns-query